### PR TITLE
Add -4, -6, --ipv4 arguments to CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-nested-ternary */
 'use strict';
 var meow = require('meow');
 var internalIp = require('./');
@@ -9,7 +10,8 @@ var cli = meow({
 		'  $ internal-ip',
 		'',
 		'Options',
-		'  --ipv6  Return the IPv6 address instead of IPv4',
+		'  -4, --ipv4  Return the IPv4 address (default)',
+		'  -6, --ipv6  Return the IPv6 address',
 		'',
 		'Examples',
 		'  $ internal-ip',
@@ -17,8 +19,13 @@ var cli = meow({
 		'  $ internal-ip --ipv6',
 		'  fe80::200:f8ff:fe21:67cf'
 	]
+}, {
+	alias: {
+		4: 'ipv4',
+		6: 'ipv6'
+	}
 });
 
-var fn = cli.flags.ipv6 ? 'v6' : 'v4';
+var fn = cli.flags.ipv4 ? 'v4' : cli.flags.ipv6 ? 'v6' : 'v4';
 
 console.log(internalIp[fn]());

--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,13 @@ $ internal-ip --help
     $ internal-ip
 
   Options
-    --ipv6  Return the IPv6 address instead of IPv4
+    -4, --ipv4  Return the IPv4 address (default)
+    -6, --ipv6  Return the IPv6 address
 
   Example
     $ internal-ip
     192.168.0.123
-    $ internal-ip --ipv6
+    $ internal-ip -6
     fe80::200:f8ff:fe21:67cf
 ```
 


### PR DESCRIPTION
Same treatment as for `public-ip`. Same linter issue exists on there too, by the way. Are you fine with disabling the rule?
