### PR TITLE
Exclude IPs that are used by Virtualbox / vagrant

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function internalIp(version) {
 	var interfaces = os.networkInterfaces();
 
 	Object.keys(interfaces).forEach(function (el) {
+		if (el.indexOf('vboxnet') > -1) {
+			return;
+		}
+
 		interfaces[el].forEach(function (el2) {
 			if (!el2.internal && el2.family === options.family) {
 				ret = el2.address;


### PR DESCRIPTION
In our company Virtualbox + vagrant is used to create local (headless) develop environments. These environments create local IPs (e.g. 33.33.33.**) to be able to connect to them through SSH. This module shows their address as being "external" while they are not. 

Example:

![screen shot 2016-12-22 at 10 03 52](https://cloud.githubusercontent.com/assets/942560/21420429/fdb73528-c82d-11e6-890f-16fb35da9594.png)

I would like to exclude interfaces with the name "vboxnet" inside them so these don't show up as external anymore. See the changes in index.js.

