### PR TITLE
Return first matching address instead of last one

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,18 +14,20 @@ var type = {
 
 function internalIp(version) {
 	var options = type[version];
-	var ret = options.def;
+	var ret;
 	var interfaces = os.networkInterfaces();
 
-	Object.keys(interfaces).forEach(function (el) {
-		interfaces[el].forEach(function (el2) {
+	Object.keys(interfaces).some(function (el) {
+		interfaces[el].some(function (el2) {
 			if (!el2.internal && el2.family === options.family) {
 				ret = el2.address;
+				return true;
 			}
 		});
+		return ret;
 	});
 
-	return ret;
+	return ret || options.def;
 }
 
 function v4() {


### PR DESCRIPTION
Return the first address matching criterias instead of the last one.  It solves my problems on *nix machines (virtual machine, docker container or vpn address was returned instead of the primary interface address)

Did'nt test on other OS.

Keep in mind that maybe there's no default gateway for the main interface.