### PR TITLE
Reimplement a synchronous method - Fixes #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,29 +8,41 @@ const defaults = {
 	v4: '127.0.0.1'
 };
 
-function internalIp(family) {
-	return defaultGateway[family]().then(result => {
-		const interfaces = os.networkInterfaces();
-		const gatewayIp = ipaddr.parse(result.gateway);
-		let ret;
+function match(gateway, family) {
+	const interfaces = os.networkInterfaces();
+	const gatewayIp = ipaddr.parse(gateway);
+	let ret;
 
-		// Look for the matching interface in all local interfaces
-		Object.keys(interfaces).some(name => {
-			return interfaces[name].some(addr => {
-				const prefix = ipaddr.parse(addr.netmask).prefixLengthFromSubnetMask();
-				const net = ipaddr.parseCIDR(`${addr.address}/${prefix}`);
+	// Look for the matching interface in all local interfaces
+	Object.keys(interfaces).some(name => {
+		return interfaces[name].some(addr => {
+			const prefix = ipaddr.parse(addr.netmask).prefixLengthFromSubnetMask();
+			const net = ipaddr.parseCIDR(`${addr.address}/${prefix}`);
 
-				if (net[0].kind() === gatewayIp.kind() && gatewayIp.match(net)) {
-					ret = net[0].toString();
-				}
+			if (net[0].kind() === gatewayIp.kind() && gatewayIp.match(net)) {
+				ret = net[0].toString();
+			}
 
-				return Boolean(ret);
-			});
+			return Boolean(ret);
 		});
+	});
 
-		return ret ? ret : defaults[family];
+	return ret ? ret : defaults[family];
+}
+
+function promise(family) {
+	return defaultGateway[family]().then(result => {
+		return match(result.gateway, family);
 	}).catch(() => defaults[family]);
 }
 
-module.exports.v6 = () => internalIp('v6');
-module.exports.v4 = () => internalIp('v4');
+function sync(family) {
+	const result = defaultGateway[family].sync();
+	return match(result.gateway, family);
+}
+
+module.exports.v6 = () => promise('v6');
+module.exports.v4 = () => promise('v4');
+
+module.exports.v6.sync = () => sync('v6');
+module.exports.v4.sync = () => sync('v4');

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const defaults = {
 	v4: '127.0.0.1'
 };
 
-function match(gateway, family) {
+function findIp(gateway, family) {
 	const interfaces = os.networkInterfaces();
 	const gatewayIp = ipaddr.parse(gateway);
 	let ret;
@@ -32,13 +32,17 @@ function match(gateway, family) {
 
 function promise(family) {
 	return defaultGateway[family]().then(result => {
-		return match(result.gateway, family);
+		return findIp(result.gateway, family);
 	}).catch(() => defaults[family]);
 }
 
 function sync(family) {
-	const result = defaultGateway[family].sync();
-	return match(result.gateway, family);
+	try {
+		const result = defaultGateway[family].sync();
+		return findIp(result.gateway, family);
+	} catch (err) {
+		return defaults[family];
+	}
 }
 
 module.exports.v6 = () => promise('v6');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"gateway"
 	],
 	"dependencies": {
-		"default-gateway": "^2.2.2",
+		"default-gateway": "^2.6.0",
 		"ipaddr.js": "^1.5.2"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -9,3 +9,11 @@ test('IPv6', async t => {
 test('IPv4', async t => {
 	t.true(isIPv4(await m.v4()));
 });
+
+test('synchronous IPv6', t => {
+	t.true(isIPv6(m.v6.sync()));
+});
+
+test('synchronous IPv4', t => {
+	t.true(isIPv4(m.v4.sync()));
+});


### PR DESCRIPTION
This PR makes use of a recent update to `default-gateway` which provides synchronous methods, to reimplement sync support in this module.