### PR TITLE
Add support for AIX platform and require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '8'
-  - '6'
-  - '4'
+  - 10
+  - 8
+  - 6

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function sync(family) {
 	try {
 		const result = defaultGateway[family].sync();
 		return findIp(result.gateway) || null;
-	} catch (err) {
+	} catch (error) {
 		return null;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -37,11 +37,12 @@
 		"linux",
 		"openbsd",
 		"sunos",
-		"win32"
+		"win32",
+		"aix"
 	],
 	"dependencies": {
-		"default-gateway": "^2.6.0",
-		"ipaddr.js": "^1.5.2"
+		"default-gateway": "^3.1.0",
+		"ipaddr.js": "^1.9.0"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
default-gateway@3.1.0 added support for the AIX platform. Also updated all dependencies and fixed one lint issue.