### PR TITLE
Remove AIX support again

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,15 @@
 		"index.js",
 		"index.d.ts"
 	],
+	"os": [
+		"android",
+		"darwin",
+		"freebsd",
+		"linux",
+		"openbsd",
+		"sunos",
+		"win32"
+	],
 	"keywords": [
 		"ip",
 		"ipv6",
@@ -32,7 +41,7 @@
 		"gateway"
 	],
 	"dependencies": {
-		"default-gateway": "^3.1.0",
+		"default-gateway": "^4.0.0",
 		"ipaddr.js": "^1.9.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"gateway"
 	],
 	"dependencies": {
-		"default-gateway": "^4.0.0",
+		"default-gateway": "^4.0.1",
 		"ipaddr.js": "^1.9.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,15 +19,6 @@
 		"index.js",
 		"index.d.ts"
 	],
-	"os": [
-		"android",
-		"darwin",
-		"freebsd",
-		"linux",
-		"openbsd",
-		"sunos",
-		"win32"
-	],
 	"keywords": [
 		"ip",
 		"ipv6",


### PR DESCRIPTION
See https://github.com/silverwind/default-gateway/issues/10. In summary, I had a `os`-locked optional native dependency to support AIX but it turns out npm has a [bug](https://npm.community/t/npm-ci-ignores-the-os-field-of-package-json/5607) where it will ignore `os` in some cases, leading to gyp error spam on commands like `npm ci` and `npm install --force`.

Dropped the platform again for this reason until someone provides a pure-js implementation. Ideally, this should be released as semver-major.