### PR TITLE
Update dependencies and require Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,9 +45,6 @@ interface v4 {
 declare const internalIp: {
 	v6: v6;
 	v4: v4;
-
-	// TODO: Remove this for the next major release
-	default: typeof internalIp;
 };
 
 export = internalIp;

--- a/index.js
+++ b/index.js
@@ -25,17 +25,20 @@ function findIp(gateway) {
 	return ip;
 }
 
-function promise(family) {
-	return defaultGateway[family]().then(result => {
+async function promise(family) {
+	try {
+		const result = await defaultGateway[family]();
 		return findIp(result.gateway) || null;
-	}).catch(() => null);
+	} catch (_) {
+		return null;
+	}
 }
 
 function sync(family) {
 	try {
 		const result = defaultGateway[family].sync();
 		return findIp(result.gateway) || null;
-	} catch (error) {
+	} catch (_) {
 		return null;
 	}
 }
@@ -47,5 +50,3 @@ internalIp.v6.sync = () => sync('v6');
 internalIp.v4.sync = () => sync('v4');
 
 module.exports = internalIp;
-// TODO: Remove this for the next major release
-module.exports.default = internalIp;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8.9.4"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -32,12 +32,12 @@
 		"gateway"
 	],
 	"dependencies": {
-		"default-gateway": "^4.2.0",
-		"ipaddr.js": "^1.9.0"
+		"default-gateway": "^5.0.4",
+		"ipaddr.js": "^1.9.1"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
+		"ava": "^2.4.0",
+		"tsd": "^0.9.0",
+		"xo": "^0.25.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8.9.4"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
- default-gateway@5 requires node 8 and brings various minor fixes
- ava@2 requires node 8.9.4
- removed module.exports.default as mentioned in the TODO
- fixed linting issues