### PR TITLE
update engines.node to match execa's

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": "^8.12.0 || >=9.7.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
`execa` used by `default-gateway` has these version requirements. This matches them (exactly).